### PR TITLE
feat: Add interactive linear algebra laboratory to projects

### DIFF
--- a/cv-data.json
+++ b/cv-data.json
@@ -78,6 +78,10 @@
       {
         "name": "Código de este sitio web",
         "url": "https://github.com/osvo/osvo.github.io/"
+      },
+      {
+        "name": "Laboratorio interactivo de álgebra lineal",
+        "url": "https://osvo.github.io/algebra-lineal/"
       }
     ]
   },


### PR DESCRIPTION
Adds the 'Laboratorio interactivo de álgebra lineal' project to the projects section in `cv-data.json`.